### PR TITLE
Escape less-than and greater-than symbols

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,11 @@ export default {
 
 						if (canvas)
 							html += `<pre style="order: ${index};"><code>
-								${canvas.replace(/\n$/, ` ${name}`)}
+								${canvas
+									.replace(/\n$/, ` ${name}`)
+									.replace(/</, `&lt;`)
+									.replace(/>/, `&gt;`)
+								}
 							</code></pre>`
 	
 						resolve(null)


### PR DESCRIPTION
replaces those strings with those `&lt;` and `&gt;` things (whatever they're called)